### PR TITLE
new release of lxml today could be causing issues with Cython

### DIFF
--- a/.github/workflows/release_bundle.yml
+++ b/.github/workflows/release_bundle.yml
@@ -92,7 +92,7 @@ jobs:
         id: install-linux-deps
         run: |
           sudo apt-get update
-          sudo apt-get install libsasl2-dev libxml2-dev libxslt-dev
+          sudo apt-get install libsasl2-dev
           python -m pip install --user --upgrade pip
           pip install -r requirements.txt
 

--- a/.github/workflows/release_bundle.yml
+++ b/.github/workflows/release_bundle.yml
@@ -42,15 +42,15 @@ jobs:
     outputs:
       python_versions: ${{ steps.build-list.outputs.versions }}
 
-    steps: 
+    steps:
       - name: "Audit Version And Parse Into Parts"
         id: semver
         uses: dbt-labs/actions/parse-semver@v1.1.0
         with:
           version: ${{ inputs.version_number }}
-      
+
       - name: "Set Python Versions"
-        # 1.0 to 1.3 support python 3.7 to 3.10 
+        # 1.0 to 1.3 support python 3.7 to 3.10
         # 1.4 added support for python 3.11
         # 1.6 drops support for python 3.7
         # Note that Python 3.8 is manually added to the matrix so not included here
@@ -67,7 +67,7 @@ jobs:
           fi
           echo $py_versions
           echo "versions=$py_versions" >> "$GITHUB_OUTPUT"
-      
+
       - name: Print Support of Python Versions Other Than 3.8
         run: |
           echo "${{ steps.build-list.outputs.versions }}"
@@ -92,7 +92,7 @@ jobs:
         id: install-linux-deps
         run: |
           sudo apt-get update
-          sudo apt-get install libsasl2-dev
+          sudo apt-get install libsasl2-dev libxml2-dev libxslt-dev
           python -m pip install --user --upgrade pip
           pip install -r requirements.txt
 
@@ -104,7 +104,7 @@ jobs:
            --input-version=${{ inputs.version_number }} \
            --operation=create
           source ./result.env
-          echo "$CREATED_TAG" 
+          echo "$CREATED_TAG"
           echo "created_tag=$CREATED_TAG" >> $GITHUB_OUTPUT
 
       - name: "Test install from Github Release"
@@ -158,7 +158,7 @@ jobs:
           echo "os_platform=mac" >> $GITHUB_ENV
 
       - name: "Install Python Dependencies"
-        run: |    
+        run: |
           python -m pip install --user --upgrade pip
           pip install -r requirements.txt
 

--- a/release_creation/bundle/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.5.latest.requirements.txt
@@ -8,7 +8,7 @@ dbt-databricks~=1.5.0
 dbt-trino~=1.5.0
 dbt-rpc~=0.4.0
 grpcio-status~=1.47.0
-lxml~=4.9
+lxml==4.9.2
 pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.39 --no-binary pyodbc

--- a/release_creation/bundle/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.5.latest.requirements.txt
@@ -8,6 +8,7 @@ dbt-databricks~=1.5.0
 dbt-trino~=1.5.0
 dbt-rpc~=0.4.0
 grpcio-status~=1.47.0
+lxml~=4.9
 pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.39 --no-binary pyodbc


### PR DESCRIPTION
today a release for `lxml` came out that does make some changes to `Cython` curious if rolling back to `4.9.2` allows build to finish

pypi: https://pypi.org/project/lxml/4.9.3/