### PR TITLE
install 1.2, 1.1 and 1.0 from git branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ major.minor version of dbt it's for so `1.3.45` release includes the latest patc
 Note that the patch version *will not* match the patch version for dbt-core or any other package as it will increment 
 with a change to any of the included python packages.  
 
+#### EOL Packages
+For dbt packages that have reached end-of-life we will be installing from the git repo instead of pypi. This will allow
+us to incorporate any security patches that are released after we have stopped updating the package on pypi.
+
 ## How to use
 To use a bundle you will need to download, unzip the archive and pass the resulting directory to pip.
 You can use the [install_bundle.sh](/install_bundle.sh) to do this for you by running the following: 

--- a/release_creation/bundle/requirements/v1.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.0.latest.requirements.txt
@@ -1,9 +1,9 @@
-dbt-core~=1.0.0  --no-binary dbt-postgres
-dbt-snowflake~=1.0.0
-dbt-bigquery~=1.0.0
-dbt-redshift~=1.0.0
-dbt-postgres~=1.0.0
-dbt-spark[PyHive,ODBC]~=1.0.0
+git+https://github.com/dbt-labs/dbt-core.git@1.0.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.0.latest#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-bigquery.git@1.0.latest#egg=dbt-bigquery
+git+https://github.com/dbt-labs/dbt-snowflake.git@1.0.latest#egg=dbt-snowflake
+git+https://github.com/dbt-labs/dbt-redshift.git@1.0.latest#egg=dbt-redshift
+git+https://github.com/dbt-labs/dbt-spark.git@1.0.latest#egg=dbt-spark[PyHive,ODBC]
 dbt-databricks~=1.0.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0

--- a/release_creation/bundle/requirements/v1.1.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.1.latest.requirements.txt
@@ -1,9 +1,9 @@
-dbt-core~=1.1.0  --no-binary dbt-postgres
-dbt-snowflake~=1.1.0
-dbt-bigquery~=1.1.0
-dbt-redshift~=1.1.0
-dbt-postgres~=1.1.0
-dbt-spark[PyHive,ODBC]~=1.1.0
+git+https://github.com/dbt-labs/dbt-core.git@1.1.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.1.latest#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-bigquery.git@1.1.latest#egg=dbt-bigquery
+git+https://github.com/dbt-labs/dbt-snowflake.git@1.1.latest#egg=dbt-snowflake
+git+https://github.com/dbt-labs/dbt-redshift.git@1.1.latest#egg=dbt-redshift
+git+https://github.com/dbt-labs/dbt-spark.git@1.1.latest#egg=dbt-spark[PyHive,ODBC]
 dbt-databricks~=1.1.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0

--- a/release_creation/bundle/requirements/v1.1.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.1.pre.requirements.txt
@@ -1,9 +1,9 @@
-dbt-core~=1.1.0b1  --no-binary dbt-postgres
-dbt-snowflake~=1.1.0b1
-dbt-bigquery~=1.1.0b1
-dbt-redshift~=1.1.0b1
-dbt-postgres~=1.1.0b1
-dbt-spark[PyHive,ODBC]~=1.1.0b1
+git+https://github.com/dbt-labs/dbt-core.git@1.1.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.1.latest#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-bigquery.git@1.1.latest#egg=dbt-bigquery
+git+https://github.com/dbt-labs/dbt-snowflake.git@1.1.latest#egg=dbt-snowflake
+git+https://github.com/dbt-labs/dbt-redshift.git@1.1.latest#egg=dbt-redshift
+git+https://github.com/dbt-labs/dbt-spark.git@1.1.latest#egg=dbt-spark[PyHive,ODBC]
 dbt-databricks~=1.1.5
 dbt-trino~=1.1.0
 dbt-rpc~=0.1.0b1

--- a/release_creation/bundle/requirements/v1.2.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.2.latest.requirements.txt
@@ -1,9 +1,9 @@
-dbt-core~=1.2.0 --no-binary dbt-postgres
-dbt-snowflake~=1.2.0
-dbt-bigquery~=1.2.0
-dbt-redshift~=1.2.0
-dbt-postgres~=1.2.0
-dbt-spark[PyHive,ODBC]~=1.2.0
+git+https://github.com/dbt-labs/dbt-core.git@1.2.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.2.latest#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-bigquery.git@1.2.latest#egg=dbt-bigquery
+git+https://github.com/dbt-labs/dbt-snowflake.git@1.2.latest#egg=dbt-snowflake
+git+https://github.com/dbt-labs/dbt-redshift.git@1.2.latest#egg=dbt-redshift
+git+https://github.com/dbt-labs/dbt-spark.git@1.2.latest#egg=dbt-spark[PyHive,ODBC]
 dbt-databricks==1.2.3
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0

--- a/release_creation/bundle/requirements/v1.2.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.2.latest.requirements.txt
@@ -4,7 +4,7 @@ git+https://github.com/dbt-labs/dbt-bigquery.git@1.2.latest#egg=dbt-bigquery
 git+https://github.com/dbt-labs/dbt-snowflake.git@1.2.latest#egg=dbt-snowflake
 git+https://github.com/dbt-labs/dbt-redshift.git@1.2.latest#egg=dbt-redshift
 git+https://github.com/dbt-labs/dbt-spark.git@1.2.latest#egg=dbt-spark[PyHive,ODBC]
-dbt-databricks==1.2.3
+dbt-databricks~=1.2.3, !=1.2.4
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyarrow!=12.0.1

--- a/release_creation/bundle/requirements/v1.2.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.2.pre.requirements.txt
@@ -1,9 +1,9 @@
-dbt-core~=1.2.0b1 --no-binary dbt-postgres
-dbt-snowflake~=1.2.0b1
-dbt-bigquery~=1.2.0b1
-dbt-redshift~=1.2.0b1
-dbt-postgres~=1.2.0b1
-dbt-spark[PyHive,ODbC]~=1.2.0b1
+git+https://github.com/dbt-labs/dbt-core.git@1.2.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.2.latest#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-bigquery.git@1.2.latest#egg=dbt-bigquery
+git+https://github.com/dbt-labs/dbt-snowflake.git@1.2.latest#egg=dbt-snowflake
+git+https://github.com/dbt-labs/dbt-redshift.git@1.2.latest#egg=dbt-redshift
+git+https://github.com/dbt-labs/dbt-spark.git@1.2.latest#egg=dbt-spark[PyHive,ODBC]
 dbt-databricks==1.2.3
 dbt-trino~=1.2.0
 dbt-rpc~=0.1.1


### PR DESCRIPTION
We want to pull in any critical security updates even if we don't end up publishing a new pypi version. 
