### PR TITLE
Pin databricks-sdk<0.2

### DIFF
--- a/release_creation/bundle/requirements/v1.4.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.4.latest.requirements.txt
@@ -15,4 +15,4 @@ pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
-databricks-sdk<0.2
+databricks-sdk==0.1.12

--- a/release_creation/bundle/requirements/v1.4.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.4.latest.requirements.txt
@@ -15,3 +15,4 @@ pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
+databricks-sdk<0.2

--- a/release_creation/bundle/requirements/v1.4.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.4.pre.requirements.txt
@@ -16,3 +16,4 @@ pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
+databricks-sdk<0.2

--- a/release_creation/bundle/requirements/v1.4.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.4.pre.requirements.txt
@@ -16,4 +16,4 @@ pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
-databricks-sdk<0.2
+databricks-sdk==0.1.12

--- a/release_creation/bundle/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.5.latest.requirements.txt
@@ -12,3 +12,4 @@ pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
+databricks-sdk<0.2

--- a/release_creation/bundle/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.5.latest.requirements.txt
@@ -12,4 +12,4 @@ pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
-databricks-sdk<0.2
+databricks-sdk==0.1.12

--- a/release_creation/bundle/requirements/v1.5.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.5.pre.requirements.txt
@@ -11,4 +11,4 @@ pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
-databricks-sdk<0.2
+databricks-sdk==0.1.12

--- a/release_creation/bundle/requirements/v1.5.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.5.pre.requirements.txt
@@ -11,3 +11,4 @@ pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
+databricks-sdk<0.2

--- a/release_creation/bundle/requirements/v1.6.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.6.pre.requirements.txt
@@ -12,4 +12,4 @@ pyasn1-modules~=0.2.1
 pyarrow~=12.0.0,!=12.0.1
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
-databricks-sdk<0.2
+databricks-sdk==0.1.12

--- a/release_creation/bundle/requirements/v1.6.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.6.pre.requirements.txt
@@ -12,3 +12,4 @@ pyasn1-modules~=0.2.1
 pyarrow~=12.0.0,!=12.0.1
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4
+databricks-sdk<0.2


### PR DESCRIPTION
Starting on July 18, we are seeing this error for some customer runs using dbt-databricks v1.4 + v1.5:

```
HTTPSConnectionPool(host='xxxx.cloud.databricks.com', port=443): Max retries exceeded with url: /sql/1.0/warehouses/xxxx (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1131)')))
```

I suspect this is due to a breaking change in the `databricks-sdk` package, which is a dependency of `dbt-databricks. Supporting evidence:
- `databricks-sdk` was introduced to the `dbt-databricks` plugin a few months ago, and it would have landed in v1.4 + v1.5: https://github.com/databricks/dbt-databricks/pull/307
- `databricks-sdk` put out its 0.2.0 + 0.2.1 releases on July 18: https://pypi.org/project/databricks-sdk/#history

This PR introduces a pin of `databricks-sdk<0.2` for all potentially affected versions:
- v1.4, v1.5, v1.6
- pre + latest