### PR TITLE
Update v1.5.pre.requirements.txt

### DIFF
--- a/release_creation/bundle/requirements/v1.5.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.5.pre.requirements.txt
@@ -1,5 +1,6 @@
 --pre
-dbt-core~=1.5.0b1 --no-binary dbt-postgres
+# core version with specific change for rotating file handler
+git+https://github.com/dbt-labs/dbt-core.git@1e4167c48095739a3be4b3812ff62bbfd15ca520#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
 dbt-snowflake~=1.5.0b1
 dbt-bigquery~=1.5.0b1
 dbt-redshift~=1.5.0b1

--- a/test/integration/bundle/test_create.py
+++ b/test/integration/bundle/test_create.py
@@ -9,7 +9,7 @@ import zipfile
 
 
 @pytest.mark.parametrize(argnames="test_version",
-                         argvalues=["1.3.0", "1.4.0", "1.5.0", "1.6.0b2"])
+                         argvalues=["1.3.0", "1.4.0", "1.5.0", "1.5.0b1", "1.6.0b2"])
 def test_generate_bundle_creates_a_bundle_with_valid_version(test_version):
     created_assets = generate_bundle(Version.coerce(test_version))
     for asset_name, asset_location in created_assets.items():


### PR DESCRIPTION
This patch updates 1.5 pre requirements to point to a not yet released version of core so that we can get changes of core into ide-server without releasing core.

Sending this up to discuss whether it makes sense to pin dbt-core versions this way rather than pinning it using beta versions