### PR TITLE
1.6.0 final release

### DIFF
--- a/.github/workflows/scheduled_releases.yml
+++ b/.github/workflows/scheduled_releases.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
        # we support the trailing four versions plus the latest pre-release
        # and the upcoming version's pre-release.
-       version: ["1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"]
+       version: ["1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0b2", "1.6.0"]
         
     name: Call Release Workflow for ${{ matrix.version }}
     uses: ./.github/workflows/release_bundle.yml

--- a/.github/workflows/scheduled_releases.yml
+++ b/.github/workflows/scheduled_releases.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
        # we support the trailing four versions plus the latest pre-release
        # and the upcoming version's pre-release.
-       version: ["1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0b2"]
+       version: ["1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"]
         
     name: Call Release Workflow for ${{ matrix.version }}
     uses: ./.github/workflows/release_bundle.yml

--- a/release_creation/bundle/requirements/v1.6.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.6.latest.requirements.txt
@@ -1,0 +1,12 @@
+dbt-core~=1.6.0 --no-binary dbt-postgres
+dbt-snowflake~=1.6.0
+dbt-bigquery~=1.6.0
+dbt-redshift~=1.6.0
+dbt-postgres~=1.6.0
+dbt-spark[PyHive,ODBC]~=1.6.0
+dbt-databricks~=1.6.0rc3
+dbt-rpc~=0.4.1
+grpcio-status~=1.56.2
+pyasn1-modules~=0.3.0
+pyodbc==4.0.39 --no-binary pyodbc
+snowflake-connector-python[secure-local-storage]~=3.0,!=3.0.4

--- a/release_creation/bundle/requirements/v1.6.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.6.latest.requirements.txt
@@ -4,9 +4,11 @@ dbt-bigquery~=1.6.0
 dbt-redshift~=1.6.0
 dbt-postgres~=1.6.0
 dbt-spark[PyHive,ODBC]~=1.6.0
-dbt-databricks~=1.6.0rc3
+# update once they have a release
+# dbt-databricks~=1.6.0
+# dbt-trino~=1.6.0
 dbt-rpc~=0.4.1
 grpcio-status~=1.56.2
 pyasn1-modules~=0.3.0
 pyodbc==4.0.39 --no-binary pyodbc
-snowflake-connector-python[secure-local-storage]~=3.0,!=3.0.4
+snowflake-connector-python ~=3.0,!=3.0.4

--- a/release_creation/main.py
+++ b/release_creation/main.py
@@ -40,7 +40,8 @@ def main():
     version = args.input_version
     operation = args.operation
     latest_version, latest_release = get_latest_bundle_release(version)
-    logger.info(f"Retrieved latest version: {latest_version} and latest release: {latest_release.tag_name}")
+    logger.info(f"Retrieved latest version: {latest_version} "
+                f"and latest release: {latest_release.tag_name if latest_release else None}")
     if operation == ReleaseOperations.create:
         target_version = latest_version
         target_version.prerelease = latest_version.prerelease

--- a/test/integration/bundle/test_create.py
+++ b/test/integration/bundle/test_create.py
@@ -9,7 +9,7 @@ import zipfile
 
 
 @pytest.mark.parametrize(argnames="test_version",
-                         argvalues=["1.3.0", "1.4.0", "1.5.0", "1.6.0b2"])
+                         argvalues=["1.3.0", "1.4.0", "1.5.0", "1.6.0"])
 def test_generate_bundle_creates_a_bundle_with_valid_version(test_version):
     created_assets = generate_bundle(Version.coerce(test_version))
     for asset_name, asset_location in created_assets.items():


### PR DESCRIPTION
resolves #63 
### Changes
- update workflow and testing to release `1.6.0` instead of `1.6.0b2`
- create `v1.6.latest.requirements.txt` from `v1.6.pre.requirements.txt` and update where appropriate

### Notable updates
- pyarrow was removed as `snowflake-connector-python` no longer installs it
- `dbt-databricks` has not released a `1.6.0final`, and is soft pinned to `1.6.0rc3`
- `dbt-bigquery` installs newer minor versions of `grpcio-status` and `pyasn1-modules`
- included `secure-local-storage` extra for `snowflake-connector-python`

## Requirements changes from `pre` to `latest`
![image](https://github.com/dbt-labs/dbt-core-bundles/assets/13974384/da28e50b-a869-4375-a279-2137ea9b8263)
