### PR TITLE
Don't fail parallel workflows in scheduled releases

### DIFF
--- a/.github/workflows/scheduled_releases.yml
+++ b/.github/workflows/scheduled_releases.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   release-bundles:
     strategy:
+      fail-fast: false
       matrix:
        # we support the trailing four versions plus the latest pre-release
        # and the upcoming version's pre-release.


### PR DESCRIPTION
Set fail-fast to false in scheduled_releases.yml
