### PR TITLE
Always release draft bundles

### DIFF
--- a/.github/actions/test_install/action.yml
+++ b/.github/actions/test_install/action.yml
@@ -32,6 +32,7 @@ runs:
     - name: "Set up venv"
       shell: bash
       run: |
+        set -e
         exit 1
         python -m venv env test_release_install
         source test_release_install/bin/activate

--- a/.github/actions/test_install/action.yml
+++ b/.github/actions/test_install/action.yml
@@ -32,8 +32,6 @@ runs:
     - name: "Set up venv"
       shell: bash
       run: |
-        set -e
-        exit 1
         python -m venv env test_release_install
         source test_release_install/bin/activate
         pip install --upgrade pip

--- a/.github/actions/test_install/action.yml
+++ b/.github/actions/test_install/action.yml
@@ -32,6 +32,7 @@ runs:
     - name: "Set up venv"
       shell: bash
       run: |
+        exit 1
         python -m venv env test_release_install
         source test_release_install/bin/activate
         pip install --upgrade pip

--- a/.github/workflows/release_draft_bundle.yml
+++ b/.github/workflows/release_draft_bundle.yml
@@ -104,11 +104,18 @@ jobs:
 
       - name: "Test install from Github Release"
         uses: ./.github/actions/test_install
+        continue-on-error: true
         with:
           tag: "${{ steps.create-release.outputs.created_tag }}"
           python_version: "3.8"
           os_platform: "linux"
           draft: true
+
+      - name: "Delete Draft if Test Install fails"
+        if: failure()
+        run: |
+          gh release delete "${{ steps.create-release.outputs.created_tag }}" -y
+          exit 1
 
       - name: "Post Notification"
         run: |

--- a/.github/workflows/release_draft_bundle.yml
+++ b/.github/workflows/release_draft_bundle.yml
@@ -73,6 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
     outputs:
       created_tag: ${{ steps.create-release.outputs.created_tag }}
       created_asset_url: ${{ steps.create-release.outputs.created_asset_url }}

--- a/.github/workflows/release_draft_bundle.yml
+++ b/.github/workflows/release_draft_bundle.yml
@@ -16,6 +16,7 @@
 # representing the release of the dependency you want to incorporate into a new
 # bundle. So if there has just been a release of dbt-core of 1.3.3 then pass that
 # as the input version (without a `v` prefix).
+# If the test install fails we delete the draft release and exit with a non-zero exit code.
 
 name: Release a Draft Bundle
 run-name: Drafting a release bundle for ${{ inputs.version_number }}

--- a/.github/workflows/release_draft_bundle.yml
+++ b/.github/workflows/release_draft_bundle.yml
@@ -103,6 +103,7 @@ jobs:
            --operation=create
 
       - name: "Test install from Github Release"
+        id: test-install
         uses: ./.github/actions/test_install
         continue-on-error: true
         with:
@@ -112,7 +113,7 @@ jobs:
           draft: true
 
       - name: "Delete Draft if Test Install fails"
-        if: failure()
+        if: steps.test-install.outcome == 'failure'
         run: |
           gh release delete "${{ steps.create-release.outputs.created_tag }}" -y
           exit 1

--- a/.github/workflows/release_new_bundle.yml
+++ b/.github/workflows/release_new_bundle.yml
@@ -43,6 +43,7 @@ jobs:
       version_number: ${{ inputs.version_number }}
 
   publish-bundles:  
+    if: ${{ always() }}
     needs: [release-draft-bundles]      
     name: Call Release Workflow for ${{ inputs.version_number }}
     uses: ./.github/workflows/publish_draft_bundle.yml


### PR DESCRIPTION
Currently if we fail to generate any of the draft bundles we skip the publish step resulting in no bundles being published. Eventually we want to add an intermediate testing step to judge what gets released but for now we just want to release any draft that has been successfully created. 