### PR TITLE
remove macosx_10_10_intel platform tag

### DIFF
--- a/release_creation/bundle/bundle_os.py
+++ b/release_creation/bundle/bundle_os.py
@@ -25,7 +25,7 @@ class BundleOS(StrEnum):
 # there isn't an authoritative source, see:
 # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/
 PIP_PLATFORM_OS_VALUES = {
-    BundleOS.MAC: ['macosx_10_9_x86_64', 'macosx_11_0_arm64', 'macosx_10_10_intel', 'macosx_12_0_arm64'],
+    BundleOS.MAC: ['macosx_10_9_x86_64', 'macosx_11_0_arm64', 'macosx_12_0_arm64'],
     BundleOS.LINUX: ['manylinux_2_17_x86_64', 'manylinux2014_x86_64', 'manylinux2014_i686',
                      'manylinux_2_17_aarch64', 'manylinux2014_aarch64']
 }


### PR DESCRIPTION
`macosx_10_10_intel` is an unusual tag that may not be well resolved for all packages.