### PR TITLE
install from latest branch

### DIFF
--- a/release_creation/bundle/requirements/v1.3.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.3.latest.requirements.txt
@@ -1,8 +1,8 @@
-dbt-core~=1.3.0 --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.3.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.3.latest#egg=dbt-postgres&subdirectory=plugins/postgres
 dbt-snowflake~=1.3.0
 dbt-bigquery~=1.3.0
 dbt-redshift~=1.3.0
-dbt-postgres~=1.3.0
 dbt-spark[PyHive,ODBC]~=1.3.0
 dbt-databricks~=1.3.0
 dbt-rpc~=0.1.1

--- a/release_creation/bundle/requirements/v1.4.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.4.latest.requirements.txt
@@ -1,9 +1,9 @@
 setuptools
-dbt-core~=1.4.0 --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.4.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.4.latest#egg=dbt-postgres&subdirectory=plugins/postgres
 dbt-snowflake~=1.4.0
 dbt-bigquery~=1.4.0
 dbt-redshift~=1.4.0
-dbt-postgres~=1.4.0
 dbt-spark[PyHive,ODBC]~=1.4.0
 dbt-databricks~=1.4.0
 dbt-trino~=1.4.0

--- a/release_creation/bundle/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.5.latest.requirements.txt
@@ -1,8 +1,8 @@
-dbt-core~=1.5.0 --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.5.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.5.latest#egg=dbt-postgres&subdirectory=plugins/postgres
 dbt-snowflake~=1.5.0
 dbt-bigquery~=1.5.0
 dbt-redshift~=1.5.0
-dbt-postgres~=1.5.0
 dbt-spark[PyHive,ODBC]~=1.5.0
 dbt-databricks~=1.5.0
 dbt-trino~=1.5.0

--- a/release_creation/bundle/requirements/v1.6.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.6.latest.requirements.txt
@@ -1,8 +1,8 @@
-dbt-core~=1.6.0 --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.6.latest#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.6.latest#egg=dbt-postgres&subdirectory=plugins/postgres
 dbt-snowflake~=1.6.0
 dbt-bigquery~=1.6.0
 dbt-redshift~=1.6.0
-dbt-postgres~=1.6.0
 dbt-spark[PyHive,ODBC]~=1.6.0
 dbt-databricks~=1.6.0
 dbt-trino~=1.6.0


### PR DESCRIPTION
All versions pre these are installing from latest branch.
We want to reduce a step between a back port make it to version branch to cloud getting that change.
@colin-rogers-dbt  thoughts?