### PR TITLE
Install linux dependencies in publish_draft_bundle.yml

### DIFF
--- a/.github/workflows/publish_draft_bundle.yml
+++ b/.github/workflows/publish_draft_bundle.yml
@@ -105,6 +105,8 @@ jobs:
       - name: "Set Linux OS"
         if: matrix.os == 'ubuntu-latest'
         run: |
+          sudo apt-get update
+          sudo apt-get install libsasl2-dev libxml2-dev libxslt-dev git gcc g++ unixodbc-dev
           echo "os_platform=linux" >> $GITHUB_ENV
 
       - name: "Set Mac OS"


### PR DESCRIPTION
We install linux dependencies in `release_draft_bundle.yml` that are not installed in `publish_draft_bundle.yml`. In particular, `libsasl2-dev` is not installed, which causes failures during release testing; the wheel for `sasl` cannot be built because it uses `pyproject.toml`. This PR adds the same linux dependencies to both files.