### PR TITLE
Fix 1.6 bundle failure due to redshift-connector==2.0.915

### DIFF
--- a/release_creation/bundle/requirements/v1.6.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.6.latest.requirements.txt
@@ -1,7 +1,8 @@
 dbt-core~=1.6.0 --no-binary dbt-postgres
 dbt-snowflake~=1.6.0
 dbt-bigquery~=1.6.0
-dbt-redshift~=1.6.0
+# we changed a dependency in dbt-redshift
+dbt-redshift~=1.6.2
 dbt-postgres~=1.6.0
 dbt-spark[PyHive,ODBC]~=1.6.0
 dbt-databricks~=1.6.0

--- a/release_creation/bundle/requirements/v1.6.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.6.latest.requirements.txt
@@ -2,7 +2,7 @@ dbt-core~=1.6.0 --no-binary dbt-postgres
 dbt-snowflake~=1.6.0
 dbt-bigquery~=1.6.0
 # we changed a dependency in dbt-redshift
-dbt-redshift~=1.6.2
+dbt-redshift~=1.6.0
 dbt-postgres~=1.6.0
 dbt-spark[PyHive,ODBC]~=1.6.0
 dbt-databricks~=1.6.0
@@ -14,3 +14,4 @@ pyasn1-modules~=0.3.0
 pyarrow~=12.0.0,!=12.0.1
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python ~=3.0,!=3.0.4
+redshift-connector>=2.0.915

--- a/test/integration/bundle/test_create.py
+++ b/test/integration/bundle/test_create.py
@@ -10,7 +10,7 @@ import zipfile
 
 @pytest.mark.parametrize(argnames="test_version",
                          argvalues=["1.3.0", "1.4.0", "1.5.0", "1.5.0rc1",
-                                    "1.6.0b2", "1.6.0", "1.7.0b1", "0.0.0"])
+                                    "1.6.0b2", "1.6.2", "1.7.0b1", "0.0.0"])
 def test_generate_bundle_creates_a_bundle_with_valid_version(test_version):
     created_assets = generate_bundle(Version.coerce(test_version))
     for asset_name, asset_location in created_assets.items():


### PR DESCRIPTION
The 1.6 bundle is failing due to a version conflict between `dbt-redshift==1.6.0` and `dbt-redshift==1.6.2`. We upgraded from `redshift-connector==2.0.913` to `redshift-connector==2.0.915` in `dbt-redshift==1.6.2`.