### PR TITLE
Add dbt-fabric to 1.7

### DIFF
--- a/release_creation/bundle/requirements/v1.7.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.7.latest.requirements.txt
@@ -6,6 +6,7 @@ dbt-postgres~=1.7.0
 dbt-spark[PyHive,ODBC]~=1.7.0
 dbt-databricks~=1.7.0
 dbt-trino~=1.7.0
+dbt-fabric~=1.7.0
 dbt-rpc~=0.4.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1


### PR DESCRIPTION
This will add dbt-fabric to 1.7.latest.requirements.txt, only merge once 1.70 of dbt-fabric has been released
