### PR TITLE
Unpin `dbt-fabric~=1.7.0` in the `1.7.latest` bundle

### DIFF
--- a/release_creation/bundle/requirements/v1.7.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.7.latest.requirements.txt
@@ -6,7 +6,7 @@ dbt-postgres~=1.7.0
 dbt-spark[PyHive,ODBC]~=1.7.0
 dbt-databricks~=1.7.0
 dbt-trino~=1.7.0
-dbt-fabric==1.7.0
+dbt-fabric~=1.7.0
 dbt-rpc~=0.4.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1


### PR DESCRIPTION
This will allow the newest version of `dbt-fabric~=1.7.0` to be deployed to Cloud. We should only merge this after confirming that the fix (adding `mssql-tools18` to the deploy image) worked in the `1.7.pre` bundle.