### PR TITLE
OpsLevel POC: `dependabot.yml`, add python version to `pyproject.toml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    rebase-strategy: "disabled"
+
+  # github dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,25 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "release_creation"
+version = "0.1.1"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "dbt Labs", email = "info@dbtlabs.com"}]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["release_creation"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[metadata]
-name = release_creation
-version = 0.1.1
-
-[options]
-packages = find:
-include_package_data = True


### PR DESCRIPTION
I configured dependabot for two things:
- pip on the root requirements file (hopefully it doesn't search down `/bundles`
- github actions

While doing this, I noticed that `setup.cfg` had settings that could be merged into `pyproject.toml`. I merged the two files and removed setup.cfg`.