### PR TITLE
Exclude Pydantic 2 from dbt-core 1.7 bundles

### DIFF
--- a/release_creation/bundle/requirements/v1.7.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.7.latest.requirements.txt
@@ -10,5 +10,6 @@ dbt-fabric~=1.7.0
 dbt-rpc~=0.4.1
 pyasn1-modules~=0.2.1
 pyarrow~=14.0.1
+pydantic~=1.10
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/bundle/requirements/v1.7.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.7.pre.requirements.txt
@@ -10,5 +10,6 @@ dbt-fabric~=1.7.0
 dbt-rpc~=0.4.1
 pyasn1-modules~=0.2.1
 pyarrow~=14.0.1
+pydantic~=1.10
 pyodbc==4.0.39 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4


### PR DESCRIPTION
We were having a weird interaction between different pydantic dep specifications, and pydantic 2 was getting install unexpectedly. This makes that impossible.