### PR TITLE
Add dbt-synapse 1.7.0rc1 to the 1.7 pre-release bundle

### DIFF
--- a/release_creation/bundle/requirements/test.requirements.txt
+++ b/release_creation/bundle/requirements/test.requirements.txt
@@ -1,4 +1,4 @@
-dbt-core --no-binary dbt-postgres
+dbt-core --no-binary
 dbt-snowflake
 dbt-bigquery
 dbt-redshift

--- a/release_creation/bundle/requirements/v0.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v0.0.latest.requirements.txt
@@ -1,3 +1,4 @@
+hatchling<2.0
 dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@main#subdirectory=core
 dbt-postgres @ git+https://github.com/dbt-labs/dbt-postgres.git@main
 dbt-bigquery @ git+https://github.com/dbt-labs/dbt-bigquery.git@main

--- a/release_creation/bundle/requirements/v0.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v0.0.latest.requirements.txt
@@ -1,12 +1,14 @@
-git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-postgres.git@main#egg=dbt-postgres
-git+https://github.com/dbt-labs/dbt-bigquery.git@main#egg=dbt-bigquery
-git+https://github.com/dbt-labs/dbt-snowflake.git@main#egg=dbt-snowflake
-git+https://github.com/dbt-labs/dbt-redshift.git@main#egg=dbt-redshift
-git+https://github.com/dbt-labs/dbt-spark.git@main#egg=dbt-spark[PyHive,ODBC]
+dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@main&subdirectory=core
+dbt-postgres @ git+https://github.com/dbt-labs/dbt-postgres.git@main
+dbt-bigquery @ git+https://github.com/dbt-labs/dbt-bigquery.git@main
+dbt-snowflake @ git+https://github.com/dbt-labs/dbt-snowflake.git@main
+dbt-redshift @ git+https://github.com/dbt-labs/dbt-redshift.git@main
+dbt-spark[PyHive,ODBC] @ git+https://github.com/dbt-labs/dbt-spark.git@main
 # need to get trino + databricks to increment version numbers in main
-# git+https://github.com/databricks/dbt-databricks.git@main#egg=dbt-databricks
-# git+https://github.com/starburstdata/dbt-trino.git@main#egg=dbt-trino
+# dbt-databricks @ git+https://github.com/databricks/dbt-databricks.git@main
+# dbt-trino @ git+https://github.com/starburstdata/dbt-trino.git@main
+# dbt-fabric @ git+https://github.com/microsoft/dbt-fabric.git@main
+# dbt-synapse @ git+https://github.com/microsoft/dbt-synapse.git@main
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyarrow!=12.0.1

--- a/release_creation/bundle/requirements/v0.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v0.0.latest.requirements.txt
@@ -1,4 +1,6 @@
 hatchling<2.0
+dbt-common @ git+https://github.com/dbt-labs/dbt-common.git@main
+dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main
 dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@main#subdirectory=core
 dbt-postgres @ git+https://github.com/dbt-labs/dbt-postgres.git@main
 dbt-bigquery @ git+https://github.com/dbt-labs/dbt-bigquery.git@main

--- a/release_creation/bundle/requirements/v0.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v0.0.latest.requirements.txt
@@ -1,4 +1,4 @@
-dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@main&subdirectory=core
+dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@main#subdirectory=core
 dbt-postgres @ git+https://github.com/dbt-labs/dbt-postgres.git@main
 dbt-bigquery @ git+https://github.com/dbt-labs/dbt-bigquery.git@main
 dbt-snowflake @ git+https://github.com/dbt-labs/dbt-snowflake.git@main

--- a/release_creation/bundle/requirements/v0.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v0.0.latest.requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-core&subdirectory=core --no-binary dbt-postgres
-git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-core&subdirectory=core --no-binary
+git+https://github.com/dbt-labs/dbt-postgres.git@main#egg=dbt-postgres
 git+https://github.com/dbt-labs/dbt-bigquery.git@main#egg=dbt-bigquery
 git+https://github.com/dbt-labs/dbt-snowflake.git@main#egg=dbt-snowflake
 git+https://github.com/dbt-labs/dbt-redshift.git@main#egg=dbt-redshift

--- a/release_creation/bundle/requirements/v0.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v0.0.latest.requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-core&subdirectory=core --no-binary
+git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-postgres.git@main#egg=dbt-postgres
 git+https://github.com/dbt-labs/dbt-bigquery.git@main#egg=dbt-bigquery
 git+https://github.com/dbt-labs/dbt-snowflake.git@main#egg=dbt-snowflake

--- a/release_creation/bundle/requirements/v1.7.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.7.latest.requirements.txt
@@ -7,6 +7,7 @@ dbt-spark[PyHive,ODBC]~=1.7.1
 dbt-databricks~=1.7.2
 dbt-trino~=1.7.0
 dbt-fabric~=1.7.0
+dbt-synapse~=1.7.0
 dbt-rpc~=0.4.1
 google-api-core<2.16.0 # see https://github.com/dbt-labs/dbt-bigquery/issues/1081
 pandas<2.2.0,>=2.0.0

--- a/release_creation/bundle/requirements/v1.7.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.7.pre.requirements.txt
@@ -7,6 +7,7 @@ dbt-spark[PyHive,ODBC]~=1.7.0rc1
 dbt-databricks~=1.7.0rc1
 dbt-trino~=1.7.0rc1
 dbt-fabric~=1.7.0
+dbt-synapse~=1.7.0rc1
 dbt-rpc~=0.4.1
 pyasn1-modules~=0.2.1
 pyarrow~=14.0.1


### PR DESCRIPTION
`dbt-synapse` has a 1.7 pre-release available. This adds the pre-release to the pre-release bundle. `dbt-synapse` has not published a final release yet.