### PR TITLE
Update `psycopg2` check to be platform-based

### DIFF
--- a/release_creation/bundle/test_archive_install.sh
+++ b/release_creation/bundle/test_archive_install.sh
@@ -14,18 +14,29 @@ python -m pip install -r "${requirements_file}" \
   --find-links ./bundle_pkg_test \
   --pre
 dbt --version
+
 # make sure psycopg2 is installed, but not psycopg2-binary
 echo -n "Checking psycopg2 install..."
-if ! pip freeze | grep psycopg2; then
-    echo "psycopg2 is not installed!"
-    exit 1
+PSYCOPG2_PIP_ENTRY=$(pip list | grep "psycopg2 " || pip list | grep psycopg2-binary)
+PSYCOPG2_NAME="${PSYCOPG2_PIP_ENTRY%% *}"
+if [[ "$OSTYPE" == linux* && "${PSYCOPG2_NAME}" == "pscyopg2" ]]; then
+  echo "psycopg2 is installed on linux as expected"
+  echo ok
+else
+  echo "psycopg2-binary is installed on linux and should not be!"
+  exit 1
 fi
-echo ok
+if [[ "$OSTYPE" == darwin* && "${PSYCOPG2_NAME}" == "pscyopg2-binary" ]]; then
+  echo "psycopg2-binary is installed on linux as expected"
+  echo ok
+else
+  echo "psycopg2 is installed on macos and should not be!"
+  exit 1
+fi
+if [[ "$OSTYPE" != linux* && "$OSTYPE" != darwin* ]]; then
+  echo "unexpected OSTYPE:"
+  echo "$OSTYPE"
+  exit 1
+fi
 
-echo -n "Checking psycopg2-binary..."
-if pip freeze | grep psycopg2-binary; then
-    echo "psycopg2-binary is installed and should not be!"
-    exit 1
-fi
-echo ok
 deactivate


### PR DESCRIPTION
We updated the `dbt-postgres` build in `1.8.0+` to install `psycopg2` based off of os platform instead of an environment variable. The check needs to be updated to match.