### PR TITLE
Pin `macos` test runners to `macos-12`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       os: ["macos-latest", "ubuntu-latest"]
+       os: ["macos-12", "ubuntu-latest"]
        python-version: ["3.8", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.python-version }} Test
@@ -65,7 +65,7 @@ jobs:
           ./.github/scripts/worker_install_linux_deps.sh
 
       - name: Set up Mac
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-12'
         run: |
           ./.github/scripts/worker_install_mac_deps.sh
 

--- a/.github/workflows/publish_draft_bundle.yml
+++ b/.github/workflows/publish_draft_bundle.yml
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{ fromJSON(needs.build-python-matrix.outputs.python_versions) }}
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-12", "ubuntu-latest"]
 
     name: ${{ matrix.os }} - ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
@@ -110,7 +110,7 @@ jobs:
           echo "os_platform=linux" >> $GITHUB_ENV
 
       - name: "Set Mac OS"
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-12'
         run: |
           echo "os_platform=mac" >> $GITHUB_ENV
 

--- a/.github/workflows/release_draft_bundle.yml
+++ b/.github/workflows/release_draft_bundle.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{ fromJSON(needs.build-python-matrix.outputs.python_versions) }}
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-12", "ubuntu-latest"]
         exclude:
           - python-version: 3.8
             os: ubuntu-latest
@@ -160,7 +160,7 @@ jobs:
           ./.github/scripts/worker_install_linux_deps.sh
 
       - name: "Install Mac Dependencies"
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-12'
         run: |
           echo "os_platform=mac" >> $GITHUB_ENV
           ./.github/scripts/worker_install_mac_deps.sh

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           if [[ ${{ inputs.os_platform }} == 'mac' ]]
           then
-            echo "platform=macos-latest" >> $GITHUB_OUTPUT
+            echo "platform=macos-12" >> $GITHUB_OUTPUT
           elif [[ ${{ inputs.os_platform }} == 'linux' ]]
           then
             echo "platform=ubuntu-latest" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Problem

`macos-latest` now points to `macos-14-arm64`; it used to point to `macos-12`. There is no `py39` nor `py38` on `macos-14-arm64`.

### Solution

Pin to `macos-12` for now and discuss long term options to use `macos-14-arm64`, and CI pinning in general.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
