### PR TITLE
Allow all versions of `dbt-adapters` into the pre file

### DIFF
--- a/release_creation/bundle/requirements/v1.8.pre.requirements.txt
+++ b/release_creation/bundle/requirements/v1.8.pre.requirements.txt
@@ -1,4 +1,4 @@
-dbt-adapters~=1.0.0b1
+dbt-adapters>=1.0.0b1
 dbt-common~=1.0.0b1
 dbt-core~=1.8.0b1
 dbt-snowflake~=1.8.0b1


### PR DESCRIPTION
We released `dbt-adapters==1.1.0rc1`, which is not getting picked up by the `1.8.pre` file because it's soft pinned to the `1.0` minor.