### PR TITLE
Update v1.7.latest.requirements.txt to exclude dbt-synapse 1.7.4

### DIFF
--- a/release_creation/bundle/requirements/v1.7.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.7.latest.requirements.txt
@@ -7,7 +7,7 @@ dbt-spark[PyHive,ODBC]~=1.7.1
 dbt-databricks~=1.7.2
 dbt-trino~=1.7.0
 dbt-fabric~=1.7.0
-dbt-synapse~=1.7.0
+dbt-synapse~=1.7.0, !=1.7.4
 dbt-rpc~=0.4.1
 google-api-core<2.16.0 # see https://github.com/dbt-labs/dbt-bigquery/issues/1081
 pandas<2.2.0,>=2.0.0


### PR DESCRIPTION
Need to skip synapse 1.7.4 as it's broken