### PR TITLE
Pin `setuptools` to avoid conflict with `packages` dep in `dbt-core`

### DIFF
--- a/release_creation/bundle/requirements/v1.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.0.latest.requirements.txt
@@ -10,6 +10,7 @@ json-rpc==1.13.0
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32
+setuptools<71.0
 # the following need to be pinned to prevent a circular dependency issue
 chardet
 charset-normalizer==3.1.0

--- a/release_creation/bundle/requirements/v1.1.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.1.latest.requirements.txt
@@ -11,5 +11,6 @@ grpcio-status~=1.47.0
 pyarrow!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32
+setuptools<71.0
 snowflake-connector-python~=3.0,!=3.0.4
 wheel

--- a/release_creation/bundle/requirements/v1.2.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.2.latest.requirements.txt
@@ -11,4 +11,5 @@ grpcio-status~=1.47.0
 pyarrow!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+setuptools<71.0
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/bundle/requirements/v1.3.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.3.latest.requirements.txt
@@ -6,12 +6,13 @@ dbt-postgres~=1.3.0
 dbt-spark[PyHive,ODBC]~=1.3.0
 dbt-databricks~=1.3.0
 dbt-rpc~=0.2.1
-json-rpc==1.13.0
+google-cloud-bigquery~=2.0
+google-cloud-dataproc~=4.0
+google-cloud-storage~=2.4
 grpcio-status~=1.47.0
+json-rpc==1.13.0
 pyarrow!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+setuptools<71.0
 snowflake-connector-python~=3.0,!=3.0.4
-google-cloud-bigquery~=2.0
-google-cloud-storage~=2.4
-google-cloud-dataproc~=4.0


### PR DESCRIPTION
`setuptools>=71.0` requires `packages>=24.0` but `dbt-core<1.4` requires `packages<22.0`.