### PR TITLE
Limit dbt 1.0.latest and 1.1.latest to numpy<2.0.0

### DIFF
--- a/release_creation/bundle/requirements/v1.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.0.latest.requirements.txt
@@ -8,6 +8,7 @@ dbt-databricks~=1.0.0
 dbt-rpc~=0.1.1
 json-rpc==1.13.0
 grpcio-status~=1.47.0
+numpy<2.0.0
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32
 setuptools<71.0

--- a/release_creation/bundle/requirements/v1.1.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v1.1.latest.requirements.txt
@@ -8,6 +8,7 @@ dbt-databricks~=1.1.0
 dbt-rpc~=0.1.1
 json-rpc==1.13.0
 grpcio-status~=1.47.0
+numpy<2.0.0
 pyarrow!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32


### PR DESCRIPTION
This ensures that the error `numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject`, which would otherwise appear when running `dbt --version`, does not occur.