### PR TITLE
Potential fix for code scanning alert no. 3: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,10 +5,8 @@ on:
   push:
     branches:
       - "main"
-  # all PRs, important to note that `pull_request_target` workflows
-  # will run in the context of the target branch of a PR since this
-  # is a public repo
-  pull_request_target:
+  # all PRs, run in the context of the PR branch (not target branch)
+  pull_request:
   workflow_dispatch:
     inputs:
       test_ref:


### PR DESCRIPTION
Potential fix for [https://github.com/dbt-labs/dbt-core-bundles/security/code-scanning/3](https://github.com/dbt-labs/dbt-core-bundles/security/code-scanning/3)

To fix the problem, the workflow should not run untrusted code (from pull requests) in the context of the default branch using `pull_request_target`. Instead, it should use the `pull_request` event, which runs in the context of the PR branch, isolating untrusted code from the default branch's cache and environment. This change should be made in the workflow trigger section at the top of `.github/workflows/integration.yml`. Specifically, remove or replace the `pull_request_target` trigger with `pull_request`. No other changes to the workflow steps are required, as the main issue is the event context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
