### PR TITLE
Pin GitHub Actions to specific SHAs (16 actions in 6 files)

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06  # actions/stale@v5
         with:
           days-before-issue-stale: 28
           days-before-issue-close: 14

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,26 +34,26 @@ jobs:
     steps:
       - name: Check out the repository (PR)
         if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check out the repository (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ inputs.test_ref }}
 
       - name: Check out the repository (non-PR)
         if: github.event_name == 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish_draft_bundle.yml
+++ b/.github/workflows/publish_draft_bundle.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
       # non-zero exit code when the release does not exist and is not currently in draft status
       - name: "Check bundle exists in draft state"
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
       - name: "Audit Version And Parse Into Parts"
         id: semver
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
       - name: "Set Linux OS"
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release_dev_bundle.yml
+++ b/.github/workflows/release_dev_bundle.yml
@@ -39,7 +39,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
       - name: "Swap Dev Bundle"
         run: |
           ./.github/scripts/swap_release_tags.sh "0.0.0+dev" "0.0.1+dev"

--- a/.github/workflows/release_draft_bundle.yml
+++ b/.github/workflows/release_draft_bundle.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
       - name: "Audit Version And Parse Into Parts"
         id: semver
@@ -83,10 +83,10 @@ jobs:
       req_file_url: ${{ steps.create-release.outputs.req_file_url }}
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
       - name: "Set up Python 3.8"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
         with:
           python-version: "3.8"
 
@@ -146,10 +146,10 @@ jobs:
 
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -78,10 +78,10 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
     - name: Set up Python "${{ inputs.python_version }}"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
       with:
         python-version: "${{ inputs.python_version }}"
 


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 6
- **Actions pinned**: 16

### 📝 Changes by file

#### `.github/workflows/release_draft_bundle.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/setup-python@v5` → `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/setup-python@v5` → `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5`

#### `.github/workflows/publish_draft_bundle.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`

#### `.github/workflows/integration.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/setup-python@v5` → `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5`

#### `.github/workflows/test_install.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/setup-python@v5` → `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5`

#### `.github/workflows/close-stale-issues.yml`

- 📌 `actions/stale@v5` → `actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06  # actions/stale@v5`

#### `.github/workflows/release_dev_bundle.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`

