### PR TITLE
Migrate dbt-core source branch from main to 1.latest

### DIFF
--- a/release_creation/bundle/requirements/v0.0.latest.requirements.txt
+++ b/release_creation/bundle/requirements/v0.0.latest.requirements.txt
@@ -1,6 +1,6 @@
 dbt-common @ git+https://github.com/dbt-labs/dbt-common.git@main
 dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters
-dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@main#subdirectory=core
+dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@1.latest#subdirectory=core
 dbt-postgres @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-postgres
 dbt-bigquery @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-bigquery
 dbt-snowflake @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-snowflake


### PR DESCRIPTION
## Summary
- Update the dev bundle requirements to pull `dbt-core` from the `1.latest` branch instead of `main`.
- Only the `dbt-core` reference in [release_creation/bundle/requirements/v0.0.latest.requirements.txt](release_creation/bundle/requirements/v0.0.latest.requirements.txt) is changed; `dbt-common`, `dbt-adapters`, and the adapter packages remain on `@main`.

This file feeds the scheduled dev bundle release (`version_number: "0.0.0"`) triggered by [.github/workflows/release_dev_bundle.yml](.github/workflows/release_dev_bundle.yml) on a daily cron.

## Test plan
- [ ] Confirm `1.latest` branch exists on `dbt-labs/dbt-core` (pip install will fail otherwise).
- [ ] Manually dispatch the `Release Dev Bundle` workflow and verify the bundle builds successfully against `dbt-core@1.latest`.
- [ ] Verify the resulting `0.0.1+dev` release artifacts install and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)